### PR TITLE
Support for Slack Interactive Messages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,83 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM golang:1
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt, install packages and tools
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
+    #
+    # Build Go tools w/module support
+    && mkdir -p /tmp/gotools \
+    && cd /tmp/gotools \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -v golang.org/x/tools/gopls@latest 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -v \
+        honnef.co/go/tools/...@latest \
+        golang.org/x/tools/cmd/gorename@latest \
+        golang.org/x/tools/cmd/goimports@latest \
+        golang.org/x/tools/cmd/guru@latest \
+        golang.org/x/lint/golint@latest \
+        github.com/mdempsky/gocode@latest \
+        github.com/cweill/gotests/...@latest \
+        github.com/haya14busa/goplay/cmd/goplay@latest \
+        github.com/sqs/goreturns@latest \
+        github.com/josharian/impl@latest \
+        github.com/davidrjenni/reftools/cmd/fillstruct@latest \
+        github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest  \
+        github.com/ramya-rao-a/go-outline@latest  \
+        github.com/acroca/go-symbols@latest  \
+        github.com/godoctor/godoctor@latest  \
+        github.com/rogpeppe/godef@latest  \
+        github.com/zmb3/gogetdoc@latest \
+        github.com/fatih/gomodifytags@latest  \
+        github.com/mgechev/revive@latest  \
+        github.com/go-delve/delve/cmd/dlv@latest 2>&1 \
+    #
+    # Build Go tools w/o module support
+    && GOPATH=/tmp/gotools go get -v github.com/alecthomas/gometalinter 2>&1 \
+    #
+    # Build gocode-gomod
+    && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && GOPATH=/tmp/gotools go build -o gocode-gomod github.com/stamblerre/gocode \
+    #
+    # Install Go tools
+    && mv /tmp/gotools/bin/* /usr/local/bin/ \
+    && mv gocode-gomod /usr/local/bin/ \
+    #
+    # Install golangci-lint
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin 2>&1 \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/gotools
+
+# Update this to "on" or "off" as appropriate
+ENV GO111MODULE=auto
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"name": "Slack Interceptor",
+	"dockerFile": "Dockerfile",
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [9000],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.gopath": "/go",
+		"go.inferGopath": true,
+		"go.useLanguageServer": true
+	},
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [
+		"golang.Go"
+	],
+	
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Comment out the next line to run as root
+	"remoteUser": "vscode"
+}

--- a/pkg/interception/handler.go
+++ b/pkg/interception/handler.go
@@ -17,9 +17,9 @@ const (
 	extractPayloadHeader = "Slack-Payload"
 	defaultPrefix        = "intercepted"
 
-	// the payload field as defined in interaction messages 
+	// the payload field as defined in interaction messages
 	// as per here: https://api.slack.com/messaging/interactivity#understanding_payloads
-	slackPayloadField 	 = "payload"
+	slackPayloadField = "payload"
 )
 
 // TODO validate the shared secret
@@ -79,9 +79,7 @@ func noFlatten(r *http.Request) bool {
 }
 
 func payloadExtract(r *http.Request) bool {
-
 	return strings.ToLower(r.Header.Get(extractPayloadHeader)) == "true"
-	//return true
 }
 
 func flattenMap(m url.Values) map[string]string {

--- a/pkg/interception/handler_test.go
+++ b/pkg/interception/handler_test.go
@@ -37,6 +37,12 @@ func TestHandlerProcessingBodySuccessfully(t *testing.T) {
 			payload: ioutil.NopCloser(bytes.NewBufferString(`field1=value1&field2=value2`)),
 			want:    []byte(`{"intercepted":{"field1":["value1"],"field2":["value2"]}}`),
 		},
+		{
+			name:    "special payload parsing",
+			headers: map[string]string{"Content-Type": mimeForm, extractPayloadHeader: "true"},
+			payload: ioutil.NopCloser(bytes.NewBufferString(`field1=value1&payload={"field2":"value2","field3":["value3a","value3b"]}`)),
+			want:    []byte(`{"intercepted":{"field2":"value2","field3":["value3a","value3b"]}}`),
+		},
 	}
 
 	for _, tt := range bodyTests {


### PR DESCRIPTION
This checkin adds the ability for the interceptor to deal with incoming messages from interactive slack messages (as if a tekton pipeline sends a message to slack).  See here for explanation of the case: https://api.slack.com/messaging/interactivity#components

See here for an example of how the interceptor is being used: https://github.com/hatmarch/tekton-comparison-demo/blob/k8-meetup-jul7/kube/tekton/triggers/slack/eventlistener-slack.yaml

This pull request also adds unobtrusive support for vscode remote (via .devcontainer)

See comments in each checkin message for more info